### PR TITLE
Use correct USB vendor string

### DIFF
--- a/usbdfu.c
+++ b/usbdfu.c
@@ -114,7 +114,7 @@ const struct usb_config_descriptor usbdfu_config = {
 const char serialnum[] __attribute__((section(".sernum"))) = "XXXXXXXXXXXXXXX";
 
 const char * const usbdfu_strings[] = {
-	"Student Robotics",
+	"University of Southampton",
 	"Bootloader firmware",
 	serialnum,
 	/* This string is used by ST Microelectronics' DfuSe utility. */


### PR DESCRIPTION
It should match the registered owner of the vendor ID, which in
this case is the University of Southampton.