### PR TITLE
Fix remaining issues in linkerscript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libopencm3"]
 	path = libopencm3
-	url = git://github.com/libopencm3/libopencm3.git
+	url = https://github.com/libopencm3/libopencm3.git

--- a/boot.c
+++ b/boot.c
@@ -10,7 +10,7 @@
 
 static void set_config_cb(usbd_device *usbd_dev, uint16_t wValue)
 {
-
+    (void)wValue;
         usbd_register_control_callback(
                                 usbd_dev,
                                 USB_REQ_TYPE_CLASS | USB_REQ_TYPE_INTERFACE,
@@ -25,13 +25,13 @@ void do_bootloader()
 
 	rcc_periph_clock_enable(RCC_GPIOA);
 
-	rcc_clock_setup_in_hsi_out_48mhz();
+	rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_HSI_48MHZ]);
 
 	gpio_clear(GPIOA, GPIO8);
 	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
 		      GPIO_CNF_OUTPUT_PUSHPULL, GPIO8);
 
-	usbd_dev = usbd_init(&stm32f103_usb_driver, &usbdfu_dev, &usbdfu_config, usbdfu_strings, 4, usbdfu_control_buffer, sizeof(usbdfu_control_buffer));
+	usbd_dev = usbd_init(&stm32f107_usb_driver, &usbdfu_dev, &usbdfu_config, usbdfu_strings, 4, usbdfu_control_buffer, sizeof(usbdfu_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, set_config_cb);
 	gpio_set(GPIOA, GPIO8);
 

--- a/stm32.ld
+++ b/stm32.ld
@@ -1,6 +1,7 @@
 /*
  * This file is part of the libopencm3 project.
  *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
  * Copyright (C) 2012 Karl Palsson <karlp@tweak.net.au>
  *
  * This library is free software: you can redistribute it and/or modify
@@ -17,7 +18,7 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Linker script for STM32F100x6, 32K flash, 4K RAM. */
+/* Based on generic linker script for STM32 targets using libopencm3. */
 
 /* Define memory regions. */
 MEMORY
@@ -26,31 +27,6 @@ MEMORY
 	rom (rx) : ORIGIN = 0x08000000, LENGTH = 8K
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 10K
 }
-
-/* Include the common ld script. */
-
-/*
- * This file is part of the libopencm3 project.
- *
- * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
- *
- * This library is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/* Generic linker script for STM32 targets using libopencm3. */
-
-/* Memory regions must be defined in the ld script which includes this one. */
 
 /* Enforce emmition of the vector table. */
 EXTERN (vector_table)

--- a/stm32.ld
+++ b/stm32.ld
@@ -22,7 +22,8 @@
 /* Define memory regions. */
 MEMORY
 {
-	rom (rx) : ORIGIN = 0x08000000, LENGTH = 32K
+	/* Restrict the bootloader to the first 8k of flash */
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 8K
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 10K
 }
 
@@ -121,9 +122,9 @@ SECTIONS
 
 	/* Finally, dump a re-enter bootloader pointer at the end of mem */
 	.text : {
-		. = 0x1FE0;
+		. = ORIGIN(rom) + 0x1FE0;
 		*(.sernum*)
-		. = 0x1FFC;
+		. = ORIGIN(rom) + 0x1FFC;
 		*(.reentry*)
 	} >rom
 

--- a/usbdfu.c
+++ b/usbdfu.c
@@ -93,7 +93,7 @@ const struct usb_interface_descriptor iface = {
 	.extralen = sizeof(dfu_function),
 };
 
-const struct usb_interface const ifaces[] = {{
+const struct usb_interface ifaces[] = {{
 	.num_altsetting = 1,
 	.altsetting = &iface,
 }};
@@ -114,7 +114,7 @@ const struct usb_config_descriptor usbdfu_config = {
 const char serialnum[] __attribute__((section(".sernum"))) = "XXXXXXXXXXXXXXX";
 
 const char * const usbdfu_strings[] = {
-	"Student Robotics",
+	"University of Southampton",
 	"Bootloader firmware",
 	serialnum,
 	/* This string is used by ST Microelectronics' DfuSe utility. */
@@ -173,37 +173,37 @@ static void usbdfu_getstatus_complete(usbd_device *usbd_dev, struct usb_setup_da
 	}
 }
 
-int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
+enum usbd_request_return_codes usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
 		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
 {
 	if ((req->bmRequestType & 0x7F) != 0x21)
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	switch (req->bRequest) {
 	case DFU_DNLOAD:
 		if ((len == NULL) || (*len == 0)) {
 			usbdfu_state = STATE_DFU_MANIFEST_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		} else {
 			/* Copy download data for use on GET_STATUS. */
 			prog.blocknum = req->wValue;
 			prog.len = *len;
 			memcpy(prog.buf, *buf, *len);
 			usbdfu_state = STATE_DFU_DNLOAD_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		}
 	case DFU_CLRSTATUS:
 		/* Clear error and return to dfuIDLE. */
 		if (usbdfu_state == STATE_DFU_ERROR)
 			usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_ABORT:
 		/* Abort returns to dfuIDLE state. */
 		usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_UPLOAD:
 		/* Upload not supported for now. */
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	case DFU_GETSTATUS: {
 		uint32_t bwPollTimeout = 0; /* 24-bit integer in DFU class spec */
 		(*buf)[0] = usbdfu_getstatus(usbd_dev, &bwPollTimeout);
@@ -214,16 +214,16 @@ int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, ui
 		(*buf)[5] = 0; /* iString not used here */
 		*len = 6;
 		*complete = usbdfu_getstatus_complete;
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case DFU_GETSTATE:
 		/* Return state with no state transision. */
 		*buf[0] = usbdfu_state;
 		*len = 1;
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
 
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 void usbdfu_sanitise()

--- a/usbdfu.h
+++ b/usbdfu.h
@@ -8,7 +8,7 @@ extern const struct usb_device_descriptor usbdfu_dev;
 extern const struct usb_config_descriptor usbdfu_config;
 extern const char *usbdfu_strings[];
 
-int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req,
+enum usbd_request_return_codes usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req,
 	uint8_t **buf, uint16_t *len,
 	void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req));
 void usbdfu_sanitise();


### PR DESCRIPTION
Currently the serial number and reentry address are beyond the end of the bootloader (probably caused by #4) which is a silent error because the linker is allowed to use the full flash range, not just the first 8k.

This fixes both these issues. ~I cannot verify this is building a valid bootloader image since I don't have a kit to work on.~